### PR TITLE
Allow adding past refuelings

### DIFF
--- a/lib/blocs/cars.dart
+++ b/lib/blocs/cars.dart
@@ -47,7 +47,7 @@ class CarsBLoC extends BLoC {
     print(mileage);
     Car car = await getCarByName(carName);
     if (car.mileage > mileage)
-      throw Exception();
+      return; // allow adding past refuelings, but odometers don't go backwards
     car.mileage = mileage;
     edit(car);
   }

--- a/lib/screens/createrefueling.dart
+++ b/lib/screens/createrefueling.dart
@@ -168,11 +168,19 @@ class CreateRefuelingScreenState extends State<CreateRefuelingScreen> {
                           ? widget.existing.odom.toString()
                           : '',
                       keyboardType: TextInputType.number,
+                      validator: (val) {
+                        try {
+                          int.parse(val);
+                        } catch (e) {
+                          return "Car Mileage must be an integer.";
+                        }
+                        return null;
+                      },
                       onSaved: (val) => setState(() {
-                            if (val != null && val != '') {
-                              refuelingItem.odom = int.parse(val);
-                            }
-                          }),
+                        if (val != null && val != '') {
+                          refuelingItem.odom = int.parse(val);
+                        }
+                      }),
                     ),
                     Padding(
                       padding: EdgeInsets.only(bottom: 16.0),


### PR DESCRIPTION
Previously the behavior was to throw an exception if we tried to roll back the odometer, but each new refueling would attempt to change the mileage. This change makes it so that the mileage updating function quietly returns without actually doing anything in the case of a past refueling.

Closes #91.