### PR TITLE
Bottom Navigation Bar color is noticeably different than card's color

### DIFF
--- a/lib/screens/homescreen.dart
+++ b/lib/screens/homescreen.dart
@@ -95,6 +95,7 @@ class HomeScreenState extends State<HomeScreen> {
         ),
         body: (signedIn) ? bodyStack : Container(),
         bottomNavigationBar: BottomNavigationBar(  
+          backgroundColor: bottomControllerColor,
           type: BottomNavigationBarType.fixed,
           showSelectedLabels: true,
           showUnselectedLabels: false,

--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -40,7 +40,7 @@ const MaterialColor tagPallette = MaterialColor(500, tagColors);
 
 const Color errorColor = Color(0xffcf6679);
 final Color cardColor = Color.lerp(mainPallette.shade900, Colors.grey[800], 0.7);
-final Color bottomControllerColor = Color.lerp(mainPallette.shade900, Colors.grey[900], 0.3);
+final Color bottomControllerColor = Color.lerp(mainPallette.shade900, Colors.grey[900], 0.7);
 
 const splashColor = Color(0xff454f51);
 
@@ -162,7 +162,6 @@ createTheme() {
     accentColorBrightness: Brightness.dark,
     canvasColor: cardColor,
     scaffoldBackgroundColor: cardColor,
-    bottomAppBarColor: bottomControllerColor,
     cardColor: cardColor,
     dividerColor: Colors.white.withAlpha(200),
     focusColor: ThemeData.dark().focusColor,


### PR DESCRIPTION
I had the wrong ThemeData parameter before so the background for the bottom nav bar was staying the same color as default material. This change makes it so that the bottom nav bar actually stands out against the background material.

Closes #80.