### PR TITLE
Fix issue with firebase queries on login/logout

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,11 +1,10 @@
+import 'package:autodo/blocs/init.dart';
 import 'package:autodo/refueling/history.dart';
-import 'package:autodo/screens/editrepeats.dart';
-import 'package:autodo/screens/newuser.dart';
-import 'package:autodo/screens/statistics.dart';
 import 'package:flutter/material.dart';
 import 'package:autodo/screens/screens.dart';
 import 'package:autodo/theme.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:autodo/blocs/blocs.dart';
 
 class AutodoApp extends StatefulWidget {
   AutodoApp() {
@@ -27,6 +26,7 @@ class AutodoAppState extends State<AutodoApp> {
   @override
   Widget build(BuildContext context) {
     var theme = createTheme();
+    startListeners();
     return MaterialApp(
       theme: theme,
       initialRoute: '/load',

--- a/lib/blocs/init.dart
+++ b/lib/blocs/init.dart
@@ -14,6 +14,10 @@ Future<void> initBLoCs(String uuid) async {
   await FilteringBLoC().initialize();
 }
 
+void startListeners() {
+  FirestoreBLoC().initialize();
+}
+
 /// Signs up a new user and creates their user document
 /// in the database.
 Future<void> initNewUser(String email, String password) async {

--- a/lib/blocs/init.dart
+++ b/lib/blocs/init.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 /// their data not being populated.
 Future<void> initBLoCs(String uuid) async {
   FirestoreBLoC().setUserDocument(uuid);
+  print('askl $uuid');
   await RepeatingBLoC().updateUpcomingTodos();
   await FilteringBLoC().initialize();
 }
@@ -16,6 +17,7 @@ Future<void> initBLoCs(String uuid) async {
 /// Signs up a new user and creates their user document
 /// in the database.
 Future<void> initNewUser(String email, String password) async {
+  FirestoreBLoC().initialize(); // starts listening for auth change
   String uuid = await Auth().signUp(email, password);
   if (uuid == null || uuid == "")
     throw SignInFailure();
@@ -34,6 +36,7 @@ Future<void> loadingSequence(BuildContext context) async {
 }
 
 Future<void> initExistingUser(String email, String password) async {
+  FirestoreBLoC().initialize(); // starts listening for auth change
   String uuid = await Auth().signIn(email, password);
   if (uuid == null || uuid == "")
     throw SignInFailure();

--- a/lib/blocs/subcomponents/firestore.dart
+++ b/lib/blocs/subcomponents/firestore.dart
@@ -1,9 +1,27 @@
 import 'dart:async';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:autodo/blocs/userauth.dart';
 
 class FirestoreBLoC {
   static final Firestore _db = Firestore.instance;
+  FirebaseUser _curUser;
   static DocumentReference userDoc;
+  StreamSubscription _authListener; // ignore: cancel_subscriptions
+
+  void _onAuthChange(FirebaseUser user) {
+    if (_curUser != null && _curUser == user) {
+      // signing out
+      userDoc = null;
+    } else if (user != null && user.uid != null) {
+      setUserDocument(user.uid);
+    }
+    _curUser = user;
+  }
+
+  void initialize() {
+    _authListener ??= Auth().listen(_onAuthChange);
+  }
 
   Future<void> createUserDocument(String uuid) async {
     userDoc = _db.collection('users').document(uuid);

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -8,3 +8,5 @@ export './logins.dart';
 export './loadingpage.dart';
 export './statistics.dart';
 export './editcarlist.dart';
+export './editrepeats.dart';
+export './newuser.dart';


### PR DESCRIPTION
Listening for auth state changes starting at the app's startup ensures that there will not be any queries to the database for documents of users that aren't logged in.

Closes #126.