### PR TITLE
Reduce set of prompts for formatting fixes and add back release action

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-on: push
+on: pull_request
 name: Dart Formatting
 jobs:
   dartfmt:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
-# https://medium.com/better-programming/ci-cd-for-flutter-apps-using-github-actions-b833f8f7aac
-on: push
-name: Test and Build apk
+on: release
+name: Test, Build and Release apk
 jobs:
   build:
     name: Build APK
@@ -25,3 +24,8 @@ jobs:
         KEY_PASSWORD: ${{ secrets.key_password }}
         STORE_FILE: ~/keystore.jks
         STORE_PASSWORD: ${{ secrets.store_password }}
+    - name: Create a Release APK
+      uses: ncipollo/release-action@v1
+      with:
+        artifacts: "build/app/outputs/apk/debug/*.apk"
+        token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
I was having to constantly merge in formatting changes to my local copy of the repo because the formatting action was set to always run on every pushed change, this makes it so that the update only happens as part of a commit.

This should additionally run the release behavior on actual releases now, but we'll see how that goes.