### PR TITLE
Dynamically create material page routes for add/edit screens

### DIFF
--- a/lib/screens/add_edit/repeat.dart
+++ b/lib/screens/add_edit/repeat.dart
@@ -164,7 +164,6 @@ class _RepeatAddEditScreenState extends State<RepeatAddEditScreen> {
                     BlocBuilder<CarsBloc, CarsState>(
                       builder: (context, state) {
                         if (state is CarsLoaded) {
-                          print('CARSSS ${state.cars}');
                           return CarsCheckboxForm(
                             cars: state.cars,
                             onSaved: (cars) => _cars = cars,

--- a/lib/screens/home/screen.dart
+++ b/lib/screens/home/screen.dart
@@ -19,7 +19,9 @@ class HomeScreen extends StatelessWidget {
   };
   final Key todosTabKey;
   final bool integrationTest;
-  final List<MaterialPageRoute> fabRoutes = [
+  // this has to be a function so that it returns a different route each time
+  // the lifecycle of a MaterialPageRoute requires that it not be reused.
+  final List<MaterialPageRoute> Function() fabRoutes = () => [
     MaterialPageRoute(
       builder: (context) => RefuelingAddEditScreen(
         isEditing: false,

--- a/lib/screens/home/screen.dart
+++ b/lib/screens/home/screen.dart
@@ -22,42 +22,43 @@ class HomeScreen extends StatelessWidget {
   // this has to be a function so that it returns a different route each time
   // the lifecycle of a MaterialPageRoute requires that it not be reused.
   final List<MaterialPageRoute> Function() fabRoutes = () => [
-    MaterialPageRoute(
-      builder: (context) => RefuelingAddEditScreen(
-        isEditing: false,
-        onSave: (m, d, a, c, n) {
-          BlocProvider.of<RefuelingsBloc>(context).add(AddRefueling(Refueling(
-            mileage: m,
-            date: d,
-            amount: a,
-            cost: c,
-            carName: n,
-          )));
-        },
-      ),
-    ),
-    MaterialPageRoute(
-        builder: (context) => TodoAddEditScreen(
-              isEditing: false,
-              onSave: (n, d, m, r, c) {
-                BlocProvider.of<TodosBloc>(context).add(AddTodo(Todo(
-                    name: n,
-                    dueDate: d,
-                    dueMileage: m,
-                    repeatName: r,
-                    carName: c,
-                    completed: false)));
-              },
-            )),
-    MaterialPageRoute(
-        builder: (context) => RepeatAddEditScreen(
-              isEditing: false,
-              onSave: (n, i, c) {
-                BlocProvider.of<RepeatsBloc>(context).add(
-                    AddRepeat(Repeat(name: n, mileageInterval: i, cars: c)));
-              },
-            ))
-  ];
+        MaterialPageRoute(
+          builder: (context) => RefuelingAddEditScreen(
+            isEditing: false,
+            onSave: (m, d, a, c, n) {
+              BlocProvider.of<RefuelingsBloc>(context)
+                  .add(AddRefueling(Refueling(
+                mileage: m,
+                date: d,
+                amount: a,
+                cost: c,
+                carName: n,
+              )));
+            },
+          ),
+        ),
+        MaterialPageRoute(
+            builder: (context) => TodoAddEditScreen(
+                  isEditing: false,
+                  onSave: (n, d, m, r, c) {
+                    BlocProvider.of<TodosBloc>(context).add(AddTodo(Todo(
+                        name: n,
+                        dueDate: d,
+                        dueMileage: m,
+                        repeatName: r,
+                        carName: c,
+                        completed: false)));
+                  },
+                )),
+        MaterialPageRoute(
+            builder: (context) => RepeatAddEditScreen(
+                  isEditing: false,
+                  onSave: (n, i, c) {
+                    BlocProvider.of<RepeatsBloc>(context).add(AddRepeat(
+                        Repeat(name: n, mileageInterval: i, cars: c)));
+                  },
+                ))
+      ];
 
   HomeScreen(
       {Key key = IntegrationTestKeys.homeScreen,

--- a/lib/widgets/src/action_button.dart
+++ b/lib/widgets/src/action_button.dart
@@ -8,7 +8,7 @@ import 'package:autodo/integ_test_keys.dart';
 class AutodoActionButton extends StatefulWidget {
   final Key mainButtonKey;
   final List<Key> miniButtonKeys;
-  final List<MaterialPageRoute> miniButtonRoutes;
+  final List<MaterialPageRoute> Function() miniButtonRoutes;
   final TickerProvider ticker;
 
   AutodoActionButton({
@@ -29,7 +29,7 @@ class _AutodoActionButtonState extends State<AutodoActionButton>
   AnimationController _controller;
   final Key mainButtonKey;
   final List<Key> miniButtonKeys;
-  final List<MaterialPageRoute> miniButtonRoutes;
+  final List<MaterialPageRoute> Function() miniButtonRoutes;
   final TickerProvider ticker;
 
   _AutodoActionButtonState(this.mainButtonKey, this.miniButtonKeys,
@@ -96,7 +96,7 @@ class _AutodoActionButtonState extends State<AutodoActionButton>
                 switchState();
                 print(index);
                 if (miniButtonRoutes != null) {
-                  Navigator.push(context, miniButtonRoutes[index]);
+                  Navigator.push(context, miniButtonRoutes()[index]);
                 }
               },
             ),


### PR DESCRIPTION
Needed to prevent issues with reusing the controller of the routes. 

Closes #170.