### PR TITLE
check for remote/local instead of base class

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,7 +131,8 @@ class App extends StatelessWidget {
         "/": (context) => BlocBuilder<AuthenticationBloc, AuthenticationState>(
               // Just here as the splitter between home screen and login screen
               builder: (context, state) {
-                if (state is RemoteAuthenticated || state is LocalAuthenticated) {
+                if (state is RemoteAuthenticated ||
+                    state is LocalAuthenticated) {
                   return homeProvider;
                 } else if (state is Unauthenticated) {
                   return welcomeProvider;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,7 +131,7 @@ class App extends StatelessWidget {
         "/": (context) => BlocBuilder<AuthenticationBloc, AuthenticationState>(
               // Just here as the splitter between home screen and login screen
               builder: (context, state) {
-                if (state is Authenticated) {
+                if (state is RemoteAuthenticated || state is LocalAuthenticated) {
                   return homeProvider;
                 } else if (state is Unauthenticated) {
                   return welcomeProvider;


### PR DESCRIPTION
Had Dad testing 0.1.6 and since he was already logged in, the check for `state is Authenticated` would always return false and show a Loading Icon. This should allow already-signed-in users to actually access the app.