### PR TITLE
Email address verification dialog

### DIFF
--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -90,6 +90,8 @@ class AutodoLocalizations {
   static String get repeatName => "Repeat Name";
   static String get editRepeat => "Edit Repeat";
   static String get addRepeat => "Add Repeat";
+  static String get verificationSent => "Verification Email Sent";
+  static String get verificationDialogContent => "Please check the specified email address for an email from auToDo. This email will contain a link through which you can verify your account and use the app.";
 }
 
 class AutodoLocalizationsDelegate

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -91,7 +91,8 @@ class AutodoLocalizations {
   static String get editRepeat => "Edit Repeat";
   static String get addRepeat => "Add Repeat";
   static String get verificationSent => "Verification Email Sent";
-  static String get verificationDialogContent => "Please check the specified email address for an email from auToDo. This email will contain a link through which you can verify your account and use the app.";
+  static String get verificationDialogContent =>
+      "Please check the specified email address for an email from auToDo. This email will contain a link through which you can verify your account and use the app.";
 }
 
 class AutodoLocalizationsDelegate

--- a/lib/screens/welcome/views/signup/form.dart
+++ b/lib/screens/welcome/views/signup/form.dart
@@ -64,6 +64,21 @@ class _SignupFormState extends State<SignupForm> {
                   ),
                 ),
               );
+          } else if (state is VerificationSent) {
+            Scaffold.of(context).hideCurrentSnackBar();
+            showDialog(  
+              context: context,
+              builder: (context) => AlertDialog(  
+                title: Text(AutodoLocalizations.verificationSent, style: Theme.of(context).primaryTextTheme.title),
+                content: Text(AutodoLocalizations.verificationDialogContent, style: Theme.of(context).primaryTextTheme.body1), 
+                actions: [  
+                  FlatButton(  
+                    child: Text(AutodoLocalizations.back, style: Theme.of(context).primaryTextTheme.button),
+                    onPressed: () => Navigator.pop(context),
+                  ),
+                ],
+              ),
+            );
           } else if (state is SignupSuccess) {
             Navigator.push(
                 context,

--- a/lib/screens/welcome/views/signup/form.dart
+++ b/lib/screens/welcome/views/signup/form.dart
@@ -72,14 +72,17 @@ class _SignupFormState extends State<SignupForm> {
               );
           } else if (state is VerificationSent) {
             Scaffold.of(context).hideCurrentSnackBar();
-            showDialog(  
+            showDialog(
               context: context,
-              builder: (context) => AlertDialog(  
-                title: Text(AutodoLocalizations.verificationSent, style: Theme.of(context).primaryTextTheme.title),
-                content: Text(AutodoLocalizations.verificationDialogContent, style: Theme.of(context).primaryTextTheme.body1), 
-                actions: [  
-                  FlatButton(  
-                    child: Text(AutodoLocalizations.back, style: Theme.of(context).primaryTextTheme.button),
+              builder: (context) => AlertDialog(
+                title: Text(AutodoLocalizations.verificationSent,
+                    style: Theme.of(context).primaryTextTheme.title),
+                content: Text(AutodoLocalizations.verificationDialogContent,
+                    style: Theme.of(context).primaryTextTheme.body1),
+                actions: [
+                  FlatButton(
+                    child: Text(AutodoLocalizations.back,
+                        style: Theme.of(context).primaryTextTheme.button),
                     onPressed: () => Navigator.pop(context),
                   ),
                 ],

--- a/lib/screens/welcome/views/signup/screen.dart
+++ b/lib/screens/welcome/views/signup/screen.dart
@@ -5,6 +5,7 @@ import 'package:autodo/blocs/blocs.dart';
 import 'package:autodo/theme.dart';
 import 'package:autodo/integ_test_keys.dart';
 import 'form.dart';
+import 'package:autodo/routes.dart';
 
 class SignupScreen extends StatelessWidget {
   SignupScreen({Key key = IntegrationTestKeys.signupScreen}) : super(key: key);
@@ -16,7 +17,7 @@ class SignupScreen extends StatelessWidget {
         appBar: AppBar(
           leading: IconButton(
             icon: Icon(Icons.arrow_back, color: Colors.grey[300]),
-            onPressed: () => Navigator.pop(context),
+            onPressed: () => Navigator.pushNamed(context, AutodoRoutes.welcome),
           ),
         ),
         body: BlocBuilder<SignupBloc, SignupState>(


### PR DESCRIPTION
Shows a dialog alerting the user that a verification email has been sent, and that's why the login hasn't completed yet.

Also fixed the issue with the back button in the signup screen.

Closes #191 and #192 