### PR TITLE
Add car tags to repeat cards

### DIFF
--- a/lib/blocs/src/repeating/bloc.dart
+++ b/lib/blocs/src/repeating/bloc.dart
@@ -12,7 +12,8 @@ import 'state.dart';
 
 class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
   final DatabaseBloc _dbBloc;
-  StreamSubscription _dbSubscription, _repoSubscription;
+  final CarsBloc _carsBloc;
+  StreamSubscription _dbSubscription, _repoSubscription, _carsSubscription;
 
   static final List<Repeat> defaults = [
     Repeat(name: "oil", mileageInterval: 3500),
@@ -32,20 +33,25 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
     Repeat(name: "coolantChange", mileageInterval: 100000)
   ];
 
-  RepeatsBloc({@required DatabaseBloc dbBloc})
-      : assert(dbBloc != null),
-        _dbBloc = dbBloc {
+  RepeatsBloc({@required DatabaseBloc dbBloc, @required CarsBloc carsBloc})
+      : assert(dbBloc != null), assert(carsBloc != null),
+        _dbBloc = dbBloc, _carsBloc = carsBloc {
     _dbSubscription = _dbBloc.listen((state) {
       if (state is DbLoaded) {
-        if (state.newUser ?? false) {
-          add(AddDefaultRepeats());
-        } else {
+        // if (state.newUser ?? false) {
+        //   add(AddDefaultRepeats());
+        // } else {
           add(LoadRepeats());
-        }
+        // }
       }
     });
     _repoSubscription = repo?.repeats()?.listen((repeats) {
       add(LoadRepeats());
+    });
+    _carsSubscription = _carsBloc.listen((state) {
+      if (state is CarsLoaded) {
+        add(RepeatCarsUpdated(state.cars));
+      }
     });
   }
 
@@ -68,6 +74,8 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
       yield* _mapDeleteRepeatToState(event);
     } else if (event is AddDefaultRepeats) {
       yield* _mapAddDefaultRepeatsToState(event);
+    } else if (event is RepeatCarsUpdated) {
+      yield* _mapRepeatCarsUpdatedToState(event);
     }
   }
 
@@ -210,19 +218,46 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
     for (var r in defaults) {
       batch.setData(r.toEntity().toDocument());
     }
-    await batch
-        .commit(); // need to wait on this, otherwise the "currentRepeats"
-    // call will return the old state
-    print('waiting on current repeats');
+    // need to wait on this, otherwise the "currentRepeats" call will return the 
+    // old state
+    await batch.commit();
     final updatedRepeats = await repo.getCurrentRepeats();
     yield RepeatsLoaded(updatedRepeats);
-    print('yielded repeats $state');
+  }
+  
+  Stream<RepeatsState> _mapRepeatCarsUpdatedToState(RepeatCarsUpdated event) async* {
+    if (repo == null) {
+      print('Error: trying to update repeats for cars update but repo is null');
+      return;
+    }
+    final curRepeats = (state as RepeatsLoaded).repeats;
+    // gets the list of cars that do not yet have a repeat associated with them
+    List<Car> newCars = event.cars
+      .map((c) => (curRepeats.any((r) => r.cars.contains(c.name)) ? null : c))
+      .toList();
+    if (newCars.length == 0) {
+      print('all cars have repeats, not adding defaults');
+      return;
+    }
+    WriteBatchWrapper batch = await repo.startRepeatWriteBatch();
+    newCars.forEach((c) {
+      defaults.forEach((r) {
+        batch.setData(r.copyWith(cars: [c.name]).toEntity().toDocument());
+      });
+    });
+    
+    // need to wait on this, otherwise the "currentRepeats" call will return the 
+    // old state
+    await batch.commit();
+    final updatedRepeats = await repo.getCurrentRepeats();
+    yield RepeatsLoaded(updatedRepeats);
   }
 
   @override
   Future<void> close() {
     _dbSubscription?.cancel();
     _repoSubscription?.cancel();
+    _carsSubscription?.cancel();
     return super.close();
   }
 }

--- a/lib/blocs/src/repeating/bloc.dart
+++ b/lib/blocs/src/repeating/bloc.dart
@@ -34,14 +34,16 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
   ];
 
   RepeatsBloc({@required DatabaseBloc dbBloc, @required CarsBloc carsBloc})
-      : assert(dbBloc != null), assert(carsBloc != null),
-        _dbBloc = dbBloc, _carsBloc = carsBloc {
+      : assert(dbBloc != null),
+        assert(carsBloc != null),
+        _dbBloc = dbBloc,
+        _carsBloc = carsBloc {
     _dbSubscription = _dbBloc.listen((state) {
       if (state is DbLoaded) {
         // if (state.newUser ?? false) {
         //   add(AddDefaultRepeats());
         // } else {
-          add(LoadRepeats());
+        add(LoadRepeats());
         // }
       }
     });
@@ -218,14 +220,15 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
     for (var r in defaults) {
       batch.setData(r.toEntity().toDocument());
     }
-    // need to wait on this, otherwise the "currentRepeats" call will return the 
+    // need to wait on this, otherwise the "currentRepeats" call will return the
     // old state
     await batch.commit();
     final updatedRepeats = await repo.getCurrentRepeats();
     yield RepeatsLoaded(updatedRepeats);
   }
-  
-  Stream<RepeatsState> _mapRepeatCarsUpdatedToState(RepeatCarsUpdated event) async* {
+
+  Stream<RepeatsState> _mapRepeatCarsUpdatedToState(
+      RepeatCarsUpdated event) async* {
     if (repo == null) {
       print('Error: trying to update repeats for cars update but repo is null');
       return;
@@ -233,8 +236,8 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
     final curRepeats = (state as RepeatsLoaded).repeats;
     // gets the list of cars that do not yet have a repeat associated with them
     List<Car> newCars = event.cars
-      .map((c) => (curRepeats.any((r) => r.cars.contains(c.name)) ? null : c))
-      .toList();
+        .map((c) => (curRepeats.any((r) => r.cars.contains(c.name)) ? null : c))
+        .toList();
     if (newCars.length == 0) {
       print('all cars have repeats, not adding defaults');
       return;
@@ -245,8 +248,8 @@ class RepeatsBloc extends Bloc<RepeatsEvent, RepeatsState> {
         batch.setData(r.copyWith(cars: [c.name]).toEntity().toDocument());
       });
     });
-    
-    // need to wait on this, otherwise the "currentRepeats" call will return the 
+
+    // need to wait on this, otherwise the "currentRepeats" call will return the
     // old state
     await batch.commit();
     final updatedRepeats = await repo.getCurrentRepeats();

--- a/lib/blocs/src/repeating/event.dart
+++ b/lib/blocs/src/repeating/event.dart
@@ -47,3 +47,15 @@ class DeleteRepeat extends RepeatsEvent {
 }
 
 class AddDefaultRepeats extends RepeatsEvent {}
+
+class RepeatCarsUpdated extends RepeatsEvent {
+  final List<Car> cars;
+
+  const RepeatCarsUpdated(this.cars);
+
+  @override 
+  List<Object> get props => [cars];
+
+  @override 
+  String toString() => 'Repeat Cars Updated { cars: $cars }';
+}

--- a/lib/blocs/src/repeating/event.dart
+++ b/lib/blocs/src/repeating/event.dart
@@ -53,9 +53,9 @@ class RepeatCarsUpdated extends RepeatsEvent {
 
   const RepeatCarsUpdated(this.cars);
 
-  @override 
+  @override
   List<Object> get props => [cars];
 
-  @override 
+  @override
   String toString() => 'Repeat Cars Updated { cars: $cars }';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,29 +63,30 @@ void run(bool integrationTest) async {
                 dbBloc: BlocProvider.of<DatabaseBloc>(context),
               )..add(LoadRefuelings()),
             ),
-            BlocProvider<RepeatsBloc>(
-              create: (context) => RepeatsBloc(
-                dbBloc: BlocProvider.of<DatabaseBloc>(context),
-              )..add(LoadRepeats()),
-            ),
           ],
           child: BlocProvider<CarsBloc>(
             create: (context) => CarsBloc(
               dbBloc: BlocProvider.of<DatabaseBloc>(context),
               refuelingsBloc: BlocProvider.of<RefuelingsBloc>(context),
             )..add(LoadCars()),
-            child: BlocProvider<TodosBloc>(
-              create: (context) => TodosBloc(
+            child: BlocProvider<RepeatsBloc>(
+              create: (context) => RepeatsBloc(
+                dbBloc: BlocProvider.of<DatabaseBloc>(context),
+                carsBloc: BlocProvider.of<CarsBloc>(context),
+              )..add(LoadRepeats()),
+              child: BlocProvider<TodosBloc>(
+                create: (context) => TodosBloc(
                   dbBloc: BlocProvider.of<DatabaseBloc>(context),
                   notificationsBloc:
                       BlocProvider.of<NotificationsBloc>(context),
                   carsBloc: BlocProvider.of<CarsBloc>(context),
                   repeatsBloc: BlocProvider.of<RepeatsBloc>(context))
                 ..add(LoadTodos()),
-              child: App(
-                  theme: theme,
-                  authRepository: authRepository,
-                  integrationTest: integrationTest),
+                child: App(
+                    theme: theme,
+                    authRepository: authRepository,
+                    integrationTest: integrationTest),
+              ),
             ),
           ),
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,12 +76,12 @@ void run(bool integrationTest) async {
               )..add(LoadRepeats()),
               child: BlocProvider<TodosBloc>(
                 create: (context) => TodosBloc(
-                  dbBloc: BlocProvider.of<DatabaseBloc>(context),
-                  notificationsBloc:
-                      BlocProvider.of<NotificationsBloc>(context),
-                  carsBloc: BlocProvider.of<CarsBloc>(context),
-                  repeatsBloc: BlocProvider.of<RepeatsBloc>(context))
-                ..add(LoadTodos()),
+                    dbBloc: BlocProvider.of<DatabaseBloc>(context),
+                    notificationsBloc:
+                        BlocProvider.of<NotificationsBloc>(context),
+                    carsBloc: BlocProvider.of<CarsBloc>(context),
+                    repeatsBloc: BlocProvider.of<RepeatsBloc>(context))
+                  ..add(LoadTodos()),
                 child: App(
                     theme: theme,
                     authRepository: authRepository,

--- a/lib/screens/home/widgets/repeat_card.dart
+++ b/lib/screens/home/widgets/repeat_card.dart
@@ -100,8 +100,8 @@ class RepeatCard extends StatelessWidget {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
         _RepeatTitle(repeat),
-        Row(  
-          children: [  
+        Row(
+          children: [
             CarTag(text: repeat.cars.first, color: Color(0xffffffff)),
             Row(
               mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/screens/home/widgets/repeat_card.dart
+++ b/lib/screens/home/widgets/repeat_card.dart
@@ -100,12 +100,17 @@ class RepeatCard extends StatelessWidget {
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
       child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
         _RepeatTitle(repeat),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: [
-            _RepeatEditButton(repeat),
-            _RepeatDeleteButton(repeat),
+        Row(  
+          children: [  
+            CarTag(text: repeat.cars.first, color: Color(0xffffffff)),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: [
+                _RepeatEditButton(repeat),
+                _RepeatDeleteButton(repeat),
+              ],
+            ),
           ],
-        )
+        ),
       ]));
 }


### PR DESCRIPTION
There are separate repeat cards created for each car, so it gets confusing unless there is a tag identifying the car that the repeat is for.

Closes #196.