### PR TITLE
Add lint rules

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,22 +3,25 @@ include: package:pedantic/analysis_options.yaml
 
 analyzer:
   errors:
-    todo: ignore
-    unawaited_futures: warning
     always_declare_return_types: error
     await_only_futures: error
+    directives_ordering: warning
     file_names: error
     prefer_final_fields: error
+    prefer_relative_imports: warning
     prefer_single_quotes: error
+    prefer_typing_uninitialized_variables: error
+    todo: ignore
+    unawaited_futures: warning
     unnecessary_parenthesis: error
     use_function_type_syntax_for_parameters: warning
-    prefer_typing_uninitialized_variables: error
 
 linter:
   rules:
     - always_declare_return_types
     - avoid_void_async
     - await_only_futures
+    - directives_ordering
     - file_names
     - omit_local_variable_types
     - prefer_const_constructors_in_immutables
@@ -29,6 +32,7 @@ linter:
     - prefer_if_null_operators
     - prefer_interpolation_to_compose_strings
     - prefer_null_aware_operators
+    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_typing_uninitialized_variables
     - sort_constructors_first

--- a/lib/blocs/blocs.dart
+++ b/lib/blocs/blocs.dart
@@ -1,13 +1,13 @@
 library blocs;
 
+export 'src/auth/barrel.dart';
 export 'src/cars/barrel.dart';
+export 'src/database/barrel.dart';
 export 'src/filtered_refuelings/barrel.dart';
 export 'src/filtered_todos/barrel.dart';
 export 'src/notifications/barrel.dart';
+export 'src/paid_version/barrel.dart';
 export 'src/refuelings/barrel.dart';
+export 'src/repeating/barrel.dart';
 export 'src/tab/barrel.dart';
 export 'src/todos/barrel.dart';
-export 'src/database/barrel.dart';
-export 'src/auth/barrel.dart';
-export 'src/repeating/barrel.dart';
-export 'src/paid_version/barrel.dart';

--- a/lib/blocs/src/auth/barrel.dart
+++ b/lib/blocs/src/auth/barrel.dart
@@ -14,6 +14,6 @@
 
 export 'bloc.dart';
 export 'event.dart';
-export 'state.dart';
-export 'signup/barrel.dart';
 export 'login/barrel.dart';
+export 'signup/barrel.dart';
+export 'state.dart';

--- a/lib/blocs/src/auth/bloc.dart
+++ b/lib/blocs/src/auth/bloc.dart
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
-import 'package:autodo/repositories/repositories.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../../../repositories/repositories.dart';
 import 'event.dart';
 import 'state.dart';
 

--- a/lib/blocs/src/auth/login/bloc.dart
+++ b/lib/blocs/src/auth/login/bloc.dart
@@ -14,15 +14,15 @@
 
 import 'dart:async';
 
-import 'package:autodo/repositories/repositories.dart';
-import 'package:flutter/foundation.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
+import '../../../../repositories/repositories.dart';
+import '../../../validators.dart';
 import '../barrel.dart';
-import 'package:autodo/blocs/validators.dart';
 import 'event.dart';
 import 'state.dart';
 

--- a/lib/blocs/src/auth/login/state.dart
+++ b/lib/blocs/src/auth/login/state.dart
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:autodo/blocs/blocs.dart';
 import 'package:equatable/equatable.dart';
+
+import '../../../blocs.dart';
 
 /// Represents the current state of the [LoginForm] fields and validation.
 abstract class LoginState extends Equatable {

--- a/lib/blocs/src/auth/signup/bloc.dart
+++ b/lib/blocs/src/auth/signup/bloc.dart
@@ -14,15 +14,15 @@
 
 import 'dart:async';
 
-import 'package:autodo/repositories/repositories.dart';
-import 'package:flutter/foundation.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 
+import '../../../../repositories/repositories.dart';
+import '../../../validators.dart';
 import '../barrel.dart';
-import 'package:autodo/blocs/validators.dart';
 import 'event.dart';
 import 'state.dart';
 

--- a/lib/blocs/src/cars/bloc.dart
+++ b/lib/blocs/src/cars/bloc.dart
@@ -1,13 +1,14 @@
 import 'dart:async';
 
-import 'package:autodo/repositories/repositories.dart';
-import 'package:flutter/foundation.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
+
+import '../../../models/models.dart';
+import '../../../repositories/repositories.dart';
+import '../database/barrel.dart';
+import '../refuelings/barrel.dart';
 import 'event.dart';
 import 'state.dart';
-import 'package:autodo/models/models.dart';
-import '../refuelings/barrel.dart';
-import '../database/barrel.dart';
 
 class CarsBloc extends Bloc<CarsEvent, CarsState> {
   CarsBloc(

--- a/lib/blocs/src/cars/event.dart
+++ b/lib/blocs/src/cars/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class CarsEvent extends Equatable {
   const CarsEvent();

--- a/lib/blocs/src/cars/state.dart
+++ b/lib/blocs/src/cars/state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class CarsState extends Equatable {
   const CarsState();

--- a/lib/blocs/src/database/bloc.dart
+++ b/lib/blocs/src/database/bloc.dart
@@ -1,15 +1,15 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:autodo/repositories/src/sembast_data_repository.dart';
 import 'package:bloc/bloc.dart';
-import 'package:flutter/material.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
 
-import 'package:autodo/repositories/repositories.dart';
+import '../../../repositories/repositories.dart';
+import '../../../repositories/src/sembast_data_repository.dart';
+import '../auth/barrel.dart';
 import 'event.dart';
 import 'state.dart';
-import '../auth/barrel.dart';
 
 class DatabaseBloc extends Bloc<DatabaseEvent, DatabaseState> {
   DatabaseBloc(

--- a/lib/blocs/src/database/state.dart
+++ b/lib/blocs/src/database/state.dart
@@ -1,6 +1,6 @@
 import 'package:equatable/equatable.dart';
 
-import 'package:autodo/repositories/repositories.dart';
+import '../../../repositories/repositories.dart';
 
 abstract class DatabaseState extends Equatable {
   const DatabaseState();

--- a/lib/blocs/src/filtered_refuelings/bloc.dart
+++ b/lib/blocs/src/filtered_refuelings/bloc.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
 
-import 'package:autodo/models/models.dart';
-import 'package:autodo/util.dart';
+import '../../../models/models.dart';
+import '../../../util.dart';
 import '../cars/barrel.dart';
 import '../refuelings/barrel.dart';
 import 'event.dart';

--- a/lib/blocs/src/filtered_refuelings/event.dart
+++ b/lib/blocs/src/filtered_refuelings/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class FilteredRefuelingsEvent extends Equatable {
   const FilteredRefuelingsEvent();

--- a/lib/blocs/src/filtered_refuelings/state.dart
+++ b/lib/blocs/src/filtered_refuelings/state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class FilteredRefuelingsState extends Equatable {
   const FilteredRefuelingsState();

--- a/lib/blocs/src/filtered_todos/bloc.dart
+++ b/lib/blocs/src/filtered_todos/bloc.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
+
 import 'package:bloc/bloc.dart';
 import 'package:meta/meta.dart';
+
+import '../../../models/models.dart';
+import '../todos/barrel.dart';
 import 'event.dart';
 import 'state.dart';
-import '../todos/barrel.dart';
-import 'package:autodo/models/models.dart';
 
 class FilteredTodosBloc extends Bloc<FilteredTodosEvent, FilteredTodosState> {
   FilteredTodosBloc({@required this.todosBloc}) {

--- a/lib/blocs/src/filtered_todos/event.dart
+++ b/lib/blocs/src/filtered_todos/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class FilteredTodosEvent extends Equatable {
   const FilteredTodosEvent();

--- a/lib/blocs/src/filtered_todos/state.dart
+++ b/lib/blocs/src/filtered_todos/state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class FilteredTodosState extends Equatable {
   const FilteredTodosState();

--- a/lib/blocs/src/notifications/bloc.dart
+++ b/lib/blocs/src/notifications/bloc.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
-import 'package:autodo/repositories/repositories.dart';
+import '../../../repositories/repositories.dart';
 import '../database/barrel.dart';
 import 'event.dart';
 import 'state.dart';

--- a/lib/blocs/src/paid_version/bloc.dart
+++ b/lib/blocs/src/paid_version/bloc.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:autodo/repositories/repositories.dart';
-import 'package:autodo/repositories/src/sembast_data_repository.dart';
 import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:in_app_purchase/in_app_purchase.dart';
 
+import '../../../repositories/repositories.dart';
+import '../../../repositories/src/sembast_data_repository.dart';
 import '../database/barrel.dart';
 import 'event.dart';
 import 'state.dart';

--- a/lib/blocs/src/refuelings/barrel.dart
+++ b/lib/blocs/src/refuelings/barrel.dart
@@ -1,3 +1,3 @@
 export 'bloc.dart';
-export 'state.dart';
 export 'event.dart';
+export 'state.dart';

--- a/lib/blocs/src/refuelings/bloc.dart
+++ b/lib/blocs/src/refuelings/bloc.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
-import 'package:autodo/blocs/blocs.dart';
-import 'package:flutter/material.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/material.dart';
 
+import '../../../models/models.dart';
+import '../../../repositories/repositories.dart';
+import '../../blocs.dart';
 import 'event.dart';
 import 'state.dart';
-import 'package:autodo/repositories/repositories.dart';
-import 'package:autodo/models/models.dart';
 
 class RefuelingsBloc extends Bloc<RefuelingsEvent, RefuelingsState> {
   RefuelingsBloc({@required dbBloc})

--- a/lib/blocs/src/refuelings/event.dart
+++ b/lib/blocs/src/refuelings/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class RefuelingsEvent extends Equatable {
   const RefuelingsEvent();

--- a/lib/blocs/src/refuelings/state.dart
+++ b/lib/blocs/src/refuelings/state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class RefuelingsState extends Equatable {
   const RefuelingsState();

--- a/lib/blocs/src/repeating/bloc.dart
+++ b/lib/blocs/src/repeating/bloc.dart
@@ -1,11 +1,11 @@
 import 'dart:async';
 
-import 'package:autodo/blocs/blocs.dart';
-import 'package:flutter/foundation.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 
-import 'package:autodo/repositories/repositories.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
+import '../../../repositories/repositories.dart';
+import '../../blocs.dart';
 import '../database/barrel.dart';
 import 'event.dart';
 import 'state.dart';

--- a/lib/blocs/src/repeating/event.dart
+++ b/lib/blocs/src/repeating/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class RepeatsEvent extends Equatable {
   const RepeatsEvent();

--- a/lib/blocs/src/repeating/state.dart
+++ b/lib/blocs/src/repeating/state.dart
@@ -1,6 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class RepeatsState extends Equatable {
   const RepeatsState();

--- a/lib/blocs/src/tab/bloc.dart
+++ b/lib/blocs/src/tab/bloc.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
+
 import 'package:bloc/bloc.dart';
+
+import '../../../models/models.dart';
 import 'event.dart';
-import 'package:autodo/models/models.dart';
 
 class TabBloc extends Bloc<TabEvent, AppTab> {
   @override

--- a/lib/blocs/src/tab/event.dart
+++ b/lib/blocs/src/tab/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class TabEvent extends Equatable {
   const TabEvent();

--- a/lib/blocs/src/todos/bloc.dart
+++ b/lib/blocs/src/todos/bloc.dart
@@ -1,18 +1,18 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:bloc/bloc.dart';
+import 'package:flutter/foundation.dart';
 
+import '../../../generated/localization.dart';
+import '../../../models/models.dart';
+import '../../../repositories/repositories.dart';
+import '../../../util.dart';
+import '../cars/barrel.dart';
+import '../database/barrel.dart';
+import '../notifications/barrel.dart';
+import '../repeating/barrel.dart';
 import 'event.dart';
 import 'state.dart';
-import 'package:autodo/repositories/repositories.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/util.dart';
-import '../cars/barrel.dart';
-import '../repeating/barrel.dart';
-import '../notifications/barrel.dart';
-import '../database/barrel.dart';
-import 'package:autodo/generated/localization.dart';
 
 class TodosBloc extends Bloc<TodosEvent, TodosState> {
   TodosBloc(

--- a/lib/blocs/src/todos/event.dart
+++ b/lib/blocs/src/todos/event.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class TodosEvent extends Equatable {
   const TodosEvent();

--- a/lib/blocs/src/todos/state.dart
+++ b/lib/blocs/src/todos/state.dart
@@ -1,5 +1,5 @@
 import 'package:equatable/equatable.dart';
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 abstract class TodosState extends Equatable {
   const TodosState();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/screens/settings/screen.dart';
 import 'package:bloc/bloc.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
@@ -17,9 +15,11 @@ import 'package:sentry/sentry.dart';
 
 import 'blocs/blocs.dart';
 import 'delegate.dart';
+import 'generated/localization.dart';
 import 'repositories/repositories.dart';
 import 'routes.dart';
 import 'screens/screens.dart';
+import 'screens/settings/screen.dart';
 import 'secret_loader.dart';
 import 'theme.dart';
 import 'units/units.dart';

--- a/lib/models/models.dart
+++ b/lib/models/models.dart
@@ -1,16 +1,16 @@
 /// Test documentation here.
 library models;
 
-export 'src/todo.dart';
-export 'src/visibility_filter.dart';
 export 'src/app_tab.dart';
-export 'src/extra_action.dart';
-export 'src/todo_due_state.dart';
-export 'src/refueling.dart';
 export 'src/car.dart';
-export 'src/repeat.dart';
-export 'src/distanceratepoint.dart';
 export 'src/distancepoint.dart';
+export 'src/distanceratepoint.dart';
+export 'src/extra_action.dart';
 export 'src/fuel_mileage_point.dart';
+export 'src/refueling.dart';
+export 'src/repeat.dart';
 export 'src/stats/driving_distance.dart';
 export 'src/stats/efficiency.dart';
+export 'src/todo.dart';
+export 'src/todo_due_state.dart';
+export 'src/visibility_filter.dart';

--- a/lib/models/src/car.dart
+++ b/lib/models/src/car.dart
@@ -1,10 +1,10 @@
-import 'package:autodo/util.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:sembast/sembast.dart';
 
+import '../../util.dart';
 import 'distanceratepoint.dart';
 
 @immutable

--- a/lib/models/src/stats/driving_distance.dart
+++ b/lib/models/src/stats/driving_distance.dart
@@ -1,9 +1,10 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/models/src/distanceratepoint.dart';
-import 'package:autodo/units/units.dart';
 import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/widgets.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../units/units.dart';
+import '../../models.dart';
+import '../distanceratepoint.dart';
 
 class DrivingDistanceStats {
   static Future<List<Series<DistanceRatePoint, DateTime>>> fetch(

--- a/lib/models/src/stats/efficiency.dart
+++ b/lib/models/src/stats/efficiency.dart
@@ -1,11 +1,12 @@
 import 'dart:math';
 
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/util.dart';
 import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/widgets.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../units/units.dart';
+import '../../../util.dart';
+import '../../models.dart';
 
 class EfficiencyStats {
   static const EMA_CUTOFF = 8;

--- a/lib/models/src/todo.dart
+++ b/lib/models/src/todo.dart
@@ -1,9 +1,10 @@
-import 'package:autodo/models/models.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 import 'package:sembast/sembast.dart';
+
+import '../models.dart';
 
 @immutable
 class Todo extends Equatable {

--- a/lib/repositories/src/data_repository.dart
+++ b/lib/repositories/src/data_repository.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 
-import 'package:autodo/models/models.dart';
-import 'package:autodo/units/units.dart';
 import 'package:equatable/equatable.dart';
 
+import '../../models/models.dart';
+import '../../units/units.dart';
 import 'write_batch_wrapper.dart';
 
 abstract class DataRepository extends Equatable {

--- a/lib/repositories/src/firebase_data_repository.dart
+++ b/lib/repositories/src/firebase_data_repository.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
-import 'package:autodo/models/models.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
-import 'package:autodo/generated/pubspec.dart';
+import '../../generated/pubspec.dart';
+import '../../models/models.dart';
 import 'data_repository.dart';
 import 'firebase_write_batch.dart';
 import 'write_batch_wrapper.dart';

--- a/lib/repositories/src/firebase_write_batch.dart
+++ b/lib/repositories/src/firebase_write_batch.dart
@@ -1,8 +1,9 @@
-import 'package:autodo/repositories/src/write_batch_wrapper.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+
+import 'write_batch_wrapper.dart';
 
 class FirebaseWriteBatch extends Equatable implements WriteBatchWrapper {
   FirebaseWriteBatch({@required firestoreInstance, @required collection})

--- a/lib/repositories/src/sembast_data_repository.dart
+++ b/lib/repositories/src/sembast_data_repository.dart
@@ -1,14 +1,15 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:semaphore/semaphore.dart';
 import 'package:sembast/sembast.dart';
 import 'package:sembast/sembast_io.dart';
-import 'package:flutter/material.dart';
-import 'package:semaphore/semaphore.dart';
 
-import 'package:autodo/generated/pubspec.dart';
-import 'package:autodo/models/models.dart';
+import '../../generated/pubspec.dart';
+import '../../models/models.dart';
+import '../repositories.dart';
 import 'data_repository.dart';
 import 'sembast_write_batch.dart';
 import 'write_batch_wrapper.dart';

--- a/lib/screens/about/about.dart
+++ b/lib/screens/about/about.dart
@@ -1,8 +1,9 @@
 import 'package:about/about.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/generated/pubspec.dart';
 import 'package:flutter/material.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../generated/localization.dart';
+import '../../generated/pubspec.dart';
 
 Future<void> about(BuildContext context) async {
   await showDialog<void>(

--- a/lib/screens/add_edit/car.dart
+++ b/lib/screens/add_edit/car.dart
@@ -1,6 +1,7 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../generated/localization.dart';
 
 class EditCarListScreen extends StatelessWidget {
   const EditCarListScreen({Key key}) : super(key: key);

--- a/lib/screens/add_edit/forms/barrel.dart
+++ b/lib/screens/add_edit/forms/barrel.dart
@@ -1,3 +1,3 @@
 export 'car_autocomplete.dart';
-export 'repeat_autocomplete.dart';
 export 'cars_checkbox.dart';
+export 'repeat_autocomplete.dart';

--- a/lib/screens/add_edit/forms/car_autocomplete.dart
+++ b/lib/screens/add_edit/forms/car_autocomplete.dart
@@ -1,13 +1,13 @@
+import 'package:autocomplete_textfield/autocomplete_textfield.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:autocomplete_textfield/autocomplete_textfield.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/util.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../generated/localization.dart';
+import '../../../models/models.dart';
+import '../../../theme.dart';
+import '../../../util.dart';
 
 class CarForm extends StatefulWidget {
   CarForm({

--- a/lib/screens/add_edit/forms/cars_checkbox.dart
+++ b/lib/screens/add_edit/forms/cars_checkbox.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import 'package:autodo/models/models.dart';
+import '../../../models/models.dart';
 
 class CarsCheckboxForm extends StatefulWidget {
   const CarsCheckboxForm({this.cars, this.onSaved});

--- a/lib/screens/add_edit/forms/repeat_autocomplete.dart
+++ b/lib/screens/add_edit/forms/repeat_autocomplete.dart
@@ -1,13 +1,13 @@
-import 'package:flutter/material.dart';
 import 'package:autocomplete_textfield/autocomplete_textfield.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/util.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../generated/localization.dart';
+import '../../../models/models.dart';
+import '../../../theme.dart';
+import '../../../util.dart';
 
 class RepeatForm extends StatefulWidget {
   const RepeatForm({

--- a/lib/screens/add_edit/refueling.dart
+++ b/lib/screens/add_edit/refueling.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/util.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../generated/localization.dart';
+import '../../models/models.dart';
+import '../../units/units.dart';
+import '../../util.dart';
 import 'forms/barrel.dart';
 
 typedef _OnSaveCallback = Function(

--- a/lib/screens/add_edit/repeat.dart
+++ b/lib/screens/add_edit/repeat.dart
@@ -1,13 +1,13 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/util.dart';
-import 'package:autodo/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
+import '../../models/models.dart';
+import '../../units/units.dart';
+import '../../util.dart';
+import '../../widgets/widgets.dart';
 import 'forms/barrel.dart';
 
 typedef _OnSaveCallback = Function(

--- a/lib/screens/add_edit/todo.dart
+++ b/lib/screens/add_edit/todo.dart
@@ -1,18 +1,18 @@
 import 'dart:async';
 
-import 'package:autodo/units/units.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
-
-import 'package:autodo/models/models.dart';
-import 'package:autodo/widgets/widgets.dart';
-import 'package:autodo/blocs/blocs.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
+import '../../integ_test_keys.dart';
+import '../../models/models.dart';
+import '../../units/units.dart';
+import '../../util.dart';
+import '../../widgets/widgets.dart';
 import 'forms/barrel.dart';
-import 'package:autodo/integ_test_keys.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/util.dart';
 
 typedef _OnSaveCallback = Function(String name, DateTime dueDate,
     double dueMileage, String repeatName, String carName);

--- a/lib/screens/home/provider.dart
+++ b/lib/screens/home/provider.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:autodo/blocs/blocs.dart';
+import '../../blocs/blocs.dart';
 
 import 'screen.dart';
 

--- a/lib/screens/home/screen.dart
+++ b/lib/screens/home/screen.dart
@@ -1,10 +1,3 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/integ_test_keys.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/screens/add_edit/barrel.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/widgets/widgets.dart';
 import 'package:firebase_admob/firebase_admob.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -12,6 +5,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
+import '../../integ_test_keys.dart';
+import '../../models/models.dart';
+import '../../units/units.dart';
+import '../../widgets/widgets.dart';
+import '../add_edit/barrel.dart';
 import 'views/barrel.dart';
 
 class HomeScreen extends StatefulWidget {

--- a/lib/screens/home/views/barrel.dart
+++ b/lib/screens/home/views/barrel.dart
@@ -1,4 +1,4 @@
-export 'repeats.dart';
 export 'refuelings.dart';
+export 'repeats.dart';
 export 'stats.dart';
 export 'todos.dart';

--- a/lib/screens/home/views/charts/barrel.dart
+++ b/lib/screens/home/views/charts/barrel.dart
@@ -1,2 +1,2 @@
-export './fuelmileage.dart';
 export './drivingdistance.dart';
+export './fuelmileage.dart';

--- a/lib/screens/home/views/charts/drivingdistance.dart
+++ b/lib/screens/home/views/charts/drivingdistance.dart
@@ -1,13 +1,13 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/widgets/widgets.dart';
 import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../models/models.dart';
+import '../../../../units/units.dart';
+import '../../../../widgets/widgets.dart';
 import 'shared.dart';
 
 class DrivingDistanceChart extends StatelessWidget {

--- a/lib/screens/home/views/charts/fuelmileage.dart
+++ b/lib/screens/home/views/charts/fuelmileage.dart
@@ -1,13 +1,13 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/widgets/widgets.dart';
 import 'package:charts_flutter/flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../models/models.dart';
+import '../../../../units/units.dart';
+import '../../../../widgets/widgets.dart';
 import 'shared.dart';
 
 class FuelMileageChart extends StatelessWidget {

--- a/lib/screens/home/views/refuelings.dart
+++ b/lib/screens/home/views/refuelings.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:autodo/widgets/widgets.dart';
-import 'package:autodo/blocs/blocs.dart';
+import '../../../blocs/blocs.dart';
+import '../../../widgets/widgets.dart';
 import '../widgets/barrel.dart';
 
 class RefuelingsScreen extends StatelessWidget {

--- a/lib/screens/home/views/repeats.dart
+++ b/lib/screens/home/views/repeats.dart
@@ -1,8 +1,8 @@
-import 'package:autodo/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:autodo/blocs/blocs.dart';
+import '../../../blocs/blocs.dart';
+import '../../../widgets/widgets.dart';
 import '../widgets/barrel.dart';
 
 class RepeatsScreen extends StatelessWidget {

--- a/lib/screens/home/views/todos.dart
+++ b/lib/screens/home/views/todos.dart
@@ -1,9 +1,9 @@
-import 'package:autodo/integ_test_keys.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/widgets/widgets.dart';
+import '../../../blocs/blocs.dart';
+import '../../../integ_test_keys.dart';
+import '../../../widgets/widgets.dart';
 import '../widgets/barrel.dart';
 
 class TodosScreen extends StatelessWidget {

--- a/lib/screens/home/widgets/barrel.dart
+++ b/lib/screens/home/widgets/barrel.dart
@@ -1,3 +1,3 @@
-export 'todo_card.dart';
 export 'refueling_card.dart';
 export 'repeat_card.dart';
+export 'todo_card.dart';

--- a/lib/screens/home/widgets/refueling_card.dart
+++ b/lib/screens/home/widgets/refueling_card.dart
@@ -1,13 +1,14 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/screens/add_edit/barrel.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../generated/localization.dart';
+import '../../../models/models.dart';
+import '../../../units/units.dart';
+import '../../../widgets/widgets.dart';
+import '../../add_edit/barrel.dart';
 
 class _RefuelingTitle extends StatelessWidget {
   const _RefuelingTitle({Key key, @required this.refueling}) : super(key: key);

--- a/lib/screens/home/widgets/repeat_card.dart
+++ b/lib/screens/home/widgets/repeat_card.dart
@@ -1,12 +1,13 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/screens/add_edit/repeat.dart';
-import 'package:autodo/units/units.dart';
-import 'package:autodo/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../generated/localization.dart';
+import '../../../models/models.dart';
+import '../../../units/units.dart';
+import '../../../widgets/widgets.dart';
+import '../../add_edit/repeat.dart';
 
 class _RepeatTitle extends StatelessWidget {
   const _RepeatTitle(this.repeat, {Key key}) : super(key: key);

--- a/lib/screens/home/widgets/todo_card.dart
+++ b/lib/screens/home/widgets/todo_card.dart
@@ -1,14 +1,14 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/screens/add_edit/barrel.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/units/units.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../../blocs/blocs.dart';
+import '../../../generated/localization.dart';
+import '../../../models/models.dart';
+import '../../../theme.dart';
+import '../../../units/units.dart';
+import '../../add_edit/barrel.dart';
 import 'todo_delete_button.dart';
 
 const int DUE_SOON_INTERVAL = 100;

--- a/lib/screens/home/widgets/todo_delete_button.dart
+++ b/lib/screens/home/widgets/todo_delete_button.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/widgets/widgets.dart';
-import 'package:autodo/models/models.dart';
+import '../../../blocs/blocs.dart';
+import '../../../models/models.dart';
+import '../../../widgets/widgets.dart';
 
 class TodoDeleteButton extends StatelessWidget {
   const TodoDeleteButton({Key key, @required this.todo}) : super(key: key);

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,4 +1,4 @@
-export 'welcome/provider.dart';
-export 'welcome/views/signup/provider.dart';
-export 'welcome/views/login/provider.dart';
 export 'home/provider.dart';
+export 'welcome/provider.dart';
+export 'welcome/views/login/provider.dart';
+export 'welcome/views/signup/provider.dart';

--- a/lib/screens/settings/screen.dart
+++ b/lib/screens/settings/screen.dart
@@ -1,12 +1,12 @@
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/units/units.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/routes.dart';
 import 'package:json_intl/json_intl.dart';
 import 'package:preferences/preferences.dart';
+
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
+import '../../routes.dart';
+import '../../units/units.dart';
 
 class SettingsScreen extends StatefulWidget {
   @override

--- a/lib/screens/welcome/screen.dart
+++ b/lib/screens/welcome/screen.dart
@@ -1,8 +1,9 @@
-import 'package:autodo/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+
+import '../../integ_test_keys.dart';
+import '../../theme.dart';
 import 'widgets/barrel.dart';
-import 'package:autodo/integ_test_keys.dart';
 
 class WelcomeScreen extends StatelessWidget {
   WelcomeScreen({Key key = IntegrationTestKeys.welcomeScreen, this.dotKeys})

--- a/lib/screens/welcome/views/barrel.dart
+++ b/lib/screens/welcome/views/barrel.dart
@@ -1,2 +1,2 @@
-export 'new_user_setup/screen.dart';
 export 'login/screen.dart';
+export 'new_user_setup/screen.dart';

--- a/lib/screens/welcome/views/login/form.dart
+++ b/lib/screens/welcome/views/login/form.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/routes.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../routes.dart';
 import '../../widgets/barrel.dart';
 
 class LoginForm extends StatefulWidget {

--- a/lib/screens/welcome/views/login/provider.dart
+++ b/lib/screens/welcome/views/login/provider.dart
@@ -1,8 +1,8 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/repositories/repositories.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../blocs/blocs.dart';
+import '../../../../repositories/repositories.dart';
 import 'screen.dart';
 
 class LoginScreenProvider extends StatelessWidget {

--- a/lib/screens/welcome/views/login/screen.dart
+++ b/lib/screens/welcome/views/login/screen.dart
@@ -1,10 +1,10 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/theme.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../theme.dart';
 import 'form.dart';
 
 class LoginScreen extends StatelessWidget {

--- a/lib/screens/welcome/views/new_user_setup/base.dart
+++ b/lib/screens/welcome/views/new_user_setup/base.dart
@@ -1,6 +1,6 @@
 import 'package:sliding_up_panel/sliding_up_panel.dart';
 import 'package:flutter/material.dart';
-import 'package:autodo/theme.dart';
+import '../../../../theme.dart';
 
 class AccountSetupScreen extends StatefulWidget {
   const AccountSetupScreen({@required this.header, @required this.panel});

--- a/lib/screens/welcome/views/new_user_setup/latestcompleted.dart
+++ b/lib/screens/welcome/views/new_user_setup/latestcompleted.dart
@@ -1,15 +1,16 @@
-import 'package:autodo/integ_test_keys.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/units/units.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/util.dart';
 import 'package:json_intl/json_intl.dart';
-import 'new_user_screen_page.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../integ_test_keys.dart';
+import '../../../../models/models.dart';
+import '../../../../theme.dart';
+import '../../../../units/units.dart';
+import '../../../../util.dart';
 import 'base.dart';
+import 'new_user_screen_page.dart';
 
 class _TodoFields extends StatefulWidget {
   const _TodoFields(this.c, this.formKey, this.showName);

--- a/lib/screens/welcome/views/new_user_setup/mileage.dart
+++ b/lib/screens/welcome/views/new_user_setup/mileage.dart
@@ -1,14 +1,14 @@
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/units/units.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/util.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/integ_test_keys.dart';
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../integ_test_keys.dart';
+import '../../../../models/models.dart';
+import '../../../../theme.dart';
+import '../../../../units/units.dart';
+import '../../../../util.dart';
 import 'base.dart';
 
 class CarEntryField extends StatefulWidget {

--- a/lib/screens/welcome/views/new_user_setup/screen.dart
+++ b/lib/screens/welcome/views/new_user_setup/screen.dart
@@ -1,14 +1,14 @@
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'package:autodo/widgets/widgets.dart';
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/integ_test_keys.dart';
-import 'package:autodo/theme.dart';
-import 'mileage.dart';
+import '../../../../blocs/blocs.dart';
+import '../../../../integ_test_keys.dart';
+import '../../../../theme.dart';
+import '../../../../widgets/widgets.dart';
 import 'latestcompleted.dart';
-import 'setrepeats.dart';
+import 'mileage.dart';
 import 'new_user_screen_page.dart';
+import 'setrepeats.dart';
 
 class NewUserScreen extends StatefulWidget {
   const NewUserScreen({Key key = IntegrationTestKeys.newUserScreen})

--- a/lib/screens/welcome/views/new_user_setup/setrepeats.dart
+++ b/lib/screens/welcome/views/new_user_setup/setrepeats.dart
@@ -1,18 +1,18 @@
-import 'package:autodo/integ_test_keys.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/units/units.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/widgets/widgets.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/util.dart';
-import 'package:autodo/routes.dart';
 import 'package:json_intl/json_intl.dart';
-import 'new_user_screen_page.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../integ_test_keys.dart';
+import '../../../../models/models.dart';
+import '../../../../routes.dart';
+import '../../../../theme.dart';
+import '../../../../units/units.dart';
+import '../../../../util.dart';
+import '../../../../widgets/widgets.dart';
 import 'base.dart';
+import 'new_user_screen_page.dart';
 
 const int cardAppearDuration = 200; // in ms
 

--- a/lib/screens/welcome/views/signup/form.dart
+++ b/lib/screens/welcome/views/signup/form.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
-import '../new_user_setup/screen.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
 import '../../widgets/barrel.dart';
+import '../new_user_setup/screen.dart';
 
 class SignupForm extends StatefulWidget {
   @override

--- a/lib/screens/welcome/views/signup/provider.dart
+++ b/lib/screens/welcome/views/signup/provider.dart
@@ -1,8 +1,8 @@
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/repositories/repositories.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../blocs/blocs.dart';
+import '../../../../repositories/repositories.dart';
 import 'screen.dart';
 
 class SignupScreenProvider extends StatelessWidget {

--- a/lib/screens/welcome/views/signup/screen.dart
+++ b/lib/screens/welcome/views/signup/screen.dart
@@ -1,13 +1,13 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/theme.dart';
-import 'package:autodo/integ_test_keys.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../integ_test_keys.dart';
+import '../../../../routes.dart';
+import '../../../../theme.dart';
 import 'form.dart';
-import 'package:autodo/routes.dart';
 
 class SignupScreen extends StatelessWidget {
   const SignupScreen({Key key = IntegrationTestKeys.signupScreen})

--- a/lib/screens/welcome/widgets/barrel.dart
+++ b/lib/screens/welcome/widgets/barrel.dart
@@ -1,6 +1,6 @@
+export 'buttons/barrel.dart';
 export 'dots_indicator.dart';
 export 'error_message.dart';
-export 'legal_notice.dart';
-export 'buttons/barrel.dart';
 export 'forms/barrel.dart';
+export 'legal_notice.dart';
 export 'scroller/barrel.dart';

--- a/lib/screens/welcome/widgets/buttons/barrel.dart
+++ b/lib/screens/welcome/widgets/buttons/barrel.dart
@@ -1,9 +1,9 @@
-export 'trial.dart';
-export 'welcome_login.dart';
-export 'welcome_signup.dart';
 export 'login_google.dart';
 export 'login_submit.dart';
 export 'login_to_signup.dart';
 export 'password_reset.dart';
 export 'signup_submit.dart';
 export 'signup_to_login.dart';
+export 'trial.dart';
+export 'welcome_login.dart';
+export 'welcome_signup.dart';

--- a/lib/screens/welcome/widgets/buttons/login_google.dart
+++ b/lib/screens/welcome/widgets/buttons/login_google.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/blocs/blocs.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
 
 class GoogleLoginButton extends StatelessWidget {
   @override

--- a/lib/screens/welcome/widgets/buttons/login_submit.dart
+++ b/lib/screens/welcome/widgets/buttons/login_submit.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
 
 class LoginSubmitButton extends StatelessWidget {
   const LoginSubmitButton({this.onPressed});

--- a/lib/screens/welcome/widgets/buttons/login_to_signup.dart
+++ b/lib/screens/welcome/widgets/buttons/login_to_signup.dart
@@ -1,9 +1,9 @@
-import 'package:autodo/routes.dart';
 import 'package:flutter/material.dart';
-
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
+import '../../../../routes.dart';
+import '../../../../theme.dart';
 
 class LoginToSignupButton extends StatelessWidget {
   @override

--- a/lib/screens/welcome/widgets/buttons/password_reset.dart
+++ b/lib/screens/welcome/widgets/buttons/password_reset.dart
@@ -1,11 +1,11 @@
-import 'package:autodo/repositories/repositories.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
+import '../../../../repositories/repositories.dart';
+import '../../../../theme.dart';
 
 class _PasswordResetDialog extends StatefulWidget {
   const _PasswordResetDialog(Key key, this.email, this.authRepository)

--- a/lib/screens/welcome/widgets/buttons/signup_submit.dart
+++ b/lib/screens/welcome/widgets/buttons/signup_submit.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
-
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
 
 class SignupSubmitButton extends StatelessWidget {
   const SignupSubmitButton({this.onPressed});

--- a/lib/screens/welcome/widgets/buttons/signup_to_login.dart
+++ b/lib/screens/welcome/widgets/buttons/signup_to_login.dart
@@ -1,9 +1,9 @@
-import 'package:autodo/routes.dart';
 import 'package:flutter/material.dart';
-
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
+import '../../../../routes.dart';
+import '../../../../theme.dart';
 
 class SignupToLoginButton extends StatelessWidget {
   @override

--- a/lib/screens/welcome/widgets/buttons/trial.dart
+++ b/lib/screens/welcome/widgets/buttons/trial.dart
@@ -1,10 +1,10 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
 import '../../views/new_user_setup/screen.dart';
 
 class TrialButton extends StatelessWidget {

--- a/lib/screens/welcome/widgets/buttons/welcome_login.dart
+++ b/lib/screens/welcome/widgets/buttons/welcome_login.dart
@@ -1,9 +1,9 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-
-import 'package:autodo/routes.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
+import '../../../../routes.dart';
 
 class LoginButton extends StatelessWidget {
   const LoginButton({Key key, this.buttonPadding}) : super(key: key);

--- a/lib/screens/welcome/widgets/buttons/welcome_signup.dart
+++ b/lib/screens/welcome/widgets/buttons/welcome_signup.dart
@@ -1,8 +1,8 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
-
-import 'package:autodo/routes.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
+import '../../../../routes.dart';
 
 class SignupButton extends StatelessWidget {
   const SignupButton({Key key, this.buttonPadding}) : super(key: key);

--- a/lib/screens/welcome/widgets/forms/email.dart
+++ b/lib/screens/welcome/widgets/forms/email.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
 
 class EmailForm extends StatelessWidget {
   const EmailForm({this.onSaved, this.node, this.nextNode, this.login = true});

--- a/lib/screens/welcome/widgets/forms/password.dart
+++ b/lib/screens/welcome/widgets/forms/password.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../blocs/blocs.dart';
+import '../../../../generated/localization.dart';
 
 class PasswordForm extends StatelessWidget {
   const PasswordForm({this.onSaved, this.node, this.login = true});

--- a/lib/screens/welcome/widgets/legal_notice.dart
+++ b/lib/screens/welcome/widgets/legal_notice.dart
@@ -1,9 +1,10 @@
 import 'package:about/about.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../generated/localization.dart';
+import '../../../theme.dart';
 
 class LegalNotice extends StatelessWidget {
   void _privacyPolicy(context) {

--- a/lib/screens/welcome/widgets/scroller/scroller.dart
+++ b/lib/screens/welcome/widgets/scroller/scroller.dart
@@ -3,9 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-import 'welcome.dart';
 import 'tutorial1.dart';
 import 'tutorial2.dart';
+import 'welcome.dart';
 
 class WelcomePageScroller extends StatefulWidget {
   WelcomePageScroller({this.lastPageNotifier});

--- a/lib/screens/welcome/widgets/scroller/tutorial1.dart
+++ b/lib/screens/welcome/widgets/scroller/tutorial1.dart
@@ -1,6 +1,7 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
 
 class Tutorial1 extends StatelessWidget {
   @override

--- a/lib/screens/welcome/widgets/scroller/tutorial2.dart
+++ b/lib/screens/welcome/widgets/scroller/tutorial2.dart
@@ -1,7 +1,8 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
 
 class Tutorial2 extends StatelessWidget {
   @override

--- a/lib/screens/welcome/widgets/scroller/welcome.dart
+++ b/lib/screens/welcome/widgets/scroller/welcome.dart
@@ -1,6 +1,7 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../../generated/localization.dart';
 
 class Welcome extends StatelessWidget {
   @override

--- a/lib/screens/welcome/widgets/verification_dialog.dart
+++ b/lib/screens/welcome/widgets/verification_dialog.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/routes.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../../blocs/blocs.dart';
+import '../../../generated/localization.dart';
+import '../../../routes.dart';
 
 class EmailVerificationDialog extends StatelessWidget {
   @override

--- a/lib/units/distance.dart
+++ b/lib/units/distance.dart
@@ -6,7 +6,7 @@ import 'package:json_intl/json_intl.dart';
 import 'package:preferences/preferences.dart';
 import 'package:provider/provider.dart';
 
-import 'package:autodo/generated/localization.dart';
+import '../generated/localization.dart';
 import 'conversion.dart';
 
 enum DistanceUnit { metric, imperial }

--- a/lib/units/volume.dart
+++ b/lib/units/volume.dart
@@ -6,7 +6,7 @@ import 'package:json_intl/json_intl.dart';
 import 'package:preferences/preferences.dart';
 import 'package:provider/provider.dart';
 
-import 'package:autodo/generated/localization.dart';
+import '../generated/localization.dart';
 import 'conversion.dart';
 
 enum VolumeUnit { metric, imperial, us }

--- a/lib/widgets/src/action_button.dart
+++ b/lib/widgets/src/action_button.dart
@@ -3,7 +3,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
-import 'package:autodo/integ_test_keys.dart';
+import '../../integ_test_keys.dart';
 
 class AutodoActionButton extends StatefulWidget {
   const AutodoActionButton({

--- a/lib/widgets/src/extra_actions.dart
+++ b/lib/widgets/src/extra_actions.dart
@@ -1,11 +1,12 @@
-import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
+import '../../models/models.dart';
 
 class ExtraActions extends StatelessWidget {
   const ExtraActions(

--- a/lib/widgets/src/legal.dart
+++ b/lib/widgets/src/legal.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/theme.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../generated/localization.dart';
+import '../../theme.dart';
 
 class PrivacyPolicy extends StatelessWidget {
   const PrivacyPolicy(this.text, {Key key, this.buttonKey}) : super(key: key);

--- a/lib/widgets/src/navdrawer.dart
+++ b/lib/widgets/src/navdrawer.dart
@@ -1,14 +1,14 @@
 import 'dart:math';
 
-import 'package:autodo/generated/localization.dart';
-import 'package:autodo/screens/about/about.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:json_intl/json_intl.dart';
 
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
+import '../../routes.dart';
+import '../../screens/about/about.dart';
 import 'sliverfooter.dart';
-import 'package:autodo/blocs/blocs.dart';
-import 'package:autodo/routes.dart';
 import 'upgrade_dialog.dart';
 
 class NavDrawer extends StatefulWidget {

--- a/lib/widgets/src/sliverfooter.dart
+++ b/lib/widgets/src/sliverfooter.dart
@@ -1,6 +1,7 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'dart:math' as math;
 
 ///
 /// Much thanks to https://stackoverflow.com/a/49621060 for this.

--- a/lib/widgets/src/snackbars.dart
+++ b/lib/widgets/src/snackbars.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../generated/localization.dart';
+import '../../models/models.dart';
 
 class DeleteTodoSnackBar extends SnackBar {
   DeleteTodoSnackBar({

--- a/lib/widgets/src/tab_selector.dart
+++ b/lib/widgets/src/tab_selector.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:autodo/models/models.dart';
-import 'package:autodo/generated/localization.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../generated/localization.dart';
+import '../../models/models.dart';
 
 class TabSelector extends StatelessWidget {
   const TabSelector(

--- a/lib/widgets/src/upgrade_dialog.dart
+++ b/lib/widgets/src/upgrade_dialog.dart
@@ -1,9 +1,9 @@
-import 'package:autodo/generated/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'package:autodo/blocs/blocs.dart';
 import 'package:json_intl/json_intl.dart';
+
+import '../../blocs/blocs.dart';
+import '../../generated/localization.dart';
 
 class UpgradeDialog extends AlertDialog {
   UpgradeDialog({Key key, @required context, @required trialUser})

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,12 +1,12 @@
 library widgets;
 
-export 'src/snackbars.dart';
-export 'src/extra_actions.dart';
-export 'src/loading_indicator.dart';
-export 'src/tab_selector.dart';
 export 'src/action_button.dart';
-export 'src/car_tag.dart';
 export 'src/autoscrollfield.dart';
-export 'src/legal.dart';
-export 'src/navdrawer.dart';
 export 'src/banner_ad.dart';
+export 'src/car_tag.dart';
+export 'src/extra_actions.dart';
+export 'src/legal.dart';
+export 'src/loading_indicator.dart';
+export 'src/navdrawer.dart';
+export 'src/snackbars.dart';
+export 'src/tab_selector.dart';

--- a/test_driver/tests/barrel.dart
+++ b/test_driver/tests/barrel.dart
@@ -1,5 +1,5 @@
 export 'auth.dart';
-export 'todos.dart';
 export 'home.dart';
 export 'refuelings.dart';
 export 'repeats.dart';
+export 'todos.dart';


### PR DESCRIPTION
Add linter rules to force organize the imports consistently.

- [prefer_relative_imports](https://dart-lang.github.io/linter/lints/prefer_relative_imports.html): When mixing relative and absolute imports it's possible to create confusion where the same member gets imported in two different ways. One way to avoid that is to ensure you consistently use relative imports for files within the lib/ directory.
- [directives_ordering](https://dart-lang.github.io/linter/lints/directives_ordering.html): Place “dart:” imports before other imports. Sort all imports. Separate  “dart:” "package:" and lib imports.

