### PR TITLE
Set the database version after upgrade

### DIFF
--- a/lib/blocs/src/database/bloc.dart
+++ b/lib/blocs/src/database/bloc.dart
@@ -53,9 +53,9 @@ class DatabaseBloc extends Bloc<DatabaseEvent, DatabaseState> {
 
   Stream<DatabaseState> _mapUserLoggedInToState(event) async* {
     final repository = await FirebaseDataRepository.open(
-      firestoreInstance: _firestoreInstance,
-      uuid: event.uuid,
-    );
+        firestoreInstance: _firestoreInstance,
+        uuid: event.uuid,
+        newUser: event.newUser);
     yield DbLoaded(repository, event.newUser);
   }
 

--- a/lib/repositories/src/data_repository.dart
+++ b/lib/repositories/src/data_repository.dart
@@ -65,7 +65,7 @@ abstract class DataRepository extends Equatable {
   // Paid or Ad-supported version
   Future<bool> getPaidStatus();
 
-  Future<void> upgrade(int curVer, int desVer) async {
+  Future<int> upgrade(int curVer, int desVer) async {
     if (curVer == 1 && desVer == 2) {
       // Move to SI units internally
       final todos = await getCurrentTodos();
@@ -117,5 +117,7 @@ abstract class DataRepository extends Equatable {
       });
       await repeatWriteBatch.commit();
     }
+
+    return desVer;
   }
 }

--- a/lib/repositories/src/firebase_data_repository.dart
+++ b/lib/repositories/src/firebase_data_repository.dart
@@ -20,7 +20,12 @@ class FirebaseDataRepository extends DataRepository {
     final userDoc = await _userDoc.get();
     final curVersion = userDoc.data['db_version'] ?? 0;
     if (curVersion != dbVersion) {
-      await upgrade(curVersion, dbVersion);
+      final newVersion = await upgrade(curVersion, dbVersion);
+      if (newVersion == dbVersion) {
+        // upgrade worked successfully
+        userDoc.data['db_version'] = newVersion;
+        await _userDoc.setData(userDoc.data);
+      }
     }
   }
 

--- a/lib/repositories/src/firebase_data_repository.dart
+++ b/lib/repositories/src/firebase_data_repository.dart
@@ -15,16 +15,24 @@ class FirebaseDataRepository extends DataRepository {
         _firestoreInstance = firestoreInstance ?? Firestore.instance,
         _uuid = uuid;
 
-  Future<void> _upgrade() async {
+  Future<void> _setDatabaseVersion(
+      DocumentSnapshot userDoc, int newVersion) async {
+    userDoc.data['db_version'] = newVersion;
+    await _userDoc.setData(userDoc.data);
+  }
+
+  Future<void> _upgrade(bool newUser) async {
     final dbVersion = Pubspec.db_version;
     final userDoc = await _userDoc.get();
-    final curVersion = userDoc.data['db_version'] ?? 0;
-    if (curVersion != dbVersion) {
+    final curVersion = userDoc.data['db_version'] ?? 1;
+
+    if (newUser) {
+      await _setDatabaseVersion(userDoc, dbVersion);
+    } else if (curVersion != dbVersion) {
       final newVersion = await upgrade(curVersion, dbVersion);
       if (newVersion == dbVersion) {
         // upgrade worked successfully
-        userDoc.data['db_version'] = newVersion;
-        await _userDoc.setData(userDoc.data);
+        await _setDatabaseVersion(userDoc, newVersion);
       }
     }
   }
@@ -35,10 +43,10 @@ class FirebaseDataRepository extends DataRepository {
   /// check the user's current database version against the expected
   /// version and migrate the data if needed.
   static Future<FirebaseDataRepository> open(
-      {Firestore firestoreInstance, @required String uuid}) async {
+      {Firestore firestoreInstance, @required String uuid, newUser}) async {
     final out = FirebaseDataRepository._(
         firestoreInstance: firestoreInstance, uuid: uuid);
-    await out._upgrade();
+    await out._upgrade(newUser ?? false);
     return out;
   }
 

--- a/lib/repositories/src/sembast_data_repository.dart
+++ b/lib/repositories/src/sembast_data_repository.dart
@@ -26,7 +26,11 @@ class SembastDataRepository extends DataRepository {
     final _db = await _openDb();
     final curVersion = _db.version;
     if (curVersion != dbVersion) {
-      await upgrade(curVersion, dbVersion);
+      final newVersion = await upgrade(curVersion, dbVersion);
+      if (newVersion == dbVersion) {
+        // upgrade went successfully
+        await StoreRef.main().record('version').put(_db, newVersion);
+      }
     }
   }
 

--- a/lib/repositories/src/sembast_data_repository.dart
+++ b/lib/repositories/src/sembast_data_repository.dart
@@ -28,7 +28,7 @@ class SembastDataRepository extends DataRepository {
     dbLock.release();
   }
 
-  Future<void> _upgrade() async {
+  Future<void> _upgrade(bool createDb) async {
     final dbVersion = Pubspec.db_version;
     await dbLock.acquire();
     final _db = await _openDb();
@@ -36,7 +36,9 @@ class SembastDataRepository extends DataRepository {
     await _db.close();
     dbLock.release();
 
-    if (curVersion != dbVersion) {
+    if (createDb) {
+      await _setDatabaseVersion(dbVersion);
+    } else if (curVersion != dbVersion) {
       final newVersion = await upgrade(curVersion, dbVersion);
       if (newVersion == dbVersion) {
         // upgrade went successfully
@@ -60,7 +62,7 @@ class SembastDataRepository extends DataRepository {
         dbFactory: dbFactory,
         dbPath: dbPath,
         pathProvider: pathProvider);
-    await out._upgrade();
+    await out._upgrade(createDb);
     return out;
   }
 


### PR DESCRIPTION
David pointed out that I was never actually setting the database version after an upgrade. The other thing he noticed was the logic in the case of an empty db was not immediately clear -- in both the firebase and sembast repos the version is assumed to be 0 in this case.

Part of #264.