### PR TITLE
Move to runZonedGuarded to fix static analysis warning

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -164,9 +164,9 @@ Future<Map> init() async {
 Future<void> main() async {
   final keys = await init();
   _sentry = SentryClient(dsn: keys['sentry-dsn']);
-  await runZoned<Future<void>>(() async {
+  await runZonedGuarded<Future<void>>(() async {
     await run(false);
-  }, onError: _reportError);
+  }, _reportError);
 }
 
 class App extends StatelessWidget {


### PR DESCRIPTION
Got a warning from flutter analyze about runZoned being deprecated in the latest version of flutter. This fixes that warning.