### PR TITLE
Update json_intl library to the official pub.dev version

### DIFF
--- a/lib/generated/pubspec.dart
+++ b/lib/generated/pubspec.dart
@@ -91,9 +91,6 @@ class Pubspec {
         'path': 'packages/firebase_admob/',
       },
     },
-    'json_intl': <dynamic, dynamic>{
-      'git': 'https://github.com/DavBfr/json_intl',
-    },
     'preferences': <dynamic, dynamic>{
       'git': <dynamic, dynamic>{
         'url': 'https://gitlab.com/davbfr/preferences.git',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -495,12 +495,10 @@ packages:
   json_intl:
     dependency: "direct main"
     description:
-      path: "."
-      ref: HEAD
-      resolved-ref: "076c442d36ee767c3a37ab0b01fa77dee5396d84"
-      url: "https://github.com/DavBfr/json_intl"
-    source: git
-    version: "0.0.2"
+      name: json_intl
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   json_rpc_2:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -62,8 +62,6 @@ dependency_overrides:
       url: git://github.com/autodo-app/flutterfire.git
       ref: master
       path: packages/firebase_admob/
-  json_intl:
-    git: https://github.com/DavBfr/json_intl
   preferences:
     git:
       url: https://gitlab.com/davbfr/preferences.git


### PR DESCRIPTION
json_intl is now published officially, with the proper documentation and tests.

https://pub.dev/packages/json_intl
